### PR TITLE
added VASPsol++ support, and support for using VASPsol++ with VTSTTools.

### DIFF
--- a/var/spack/repos/builtin/packages/vasp/README.md
+++ b/var/spack/repos/builtin/packages/vasp/README.md
@@ -1,0 +1,3 @@
+# VASP Spack Package Notes
+
+Note that VASP is proprietary software, and that users must obtain their own licensed copy of the source code. The patches in this package contain minimal amounts of VASP source code, and are publicized with the permission of the VASP developers. The VASPsol++ patches were written by Craig Plaisance and are used here with permission.

--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -52,11 +52,19 @@ class Vasp(MakefilePackage, CudaPackage):
         when="+vaspsol",
     )
 
+    # specify exact commit as there is no appropriate tag available
+    resource(
+        name="vaspsolpp",
+        git="https://github.com/VASPsol/VASPsol.git",
+        commit="6626f27",
+        when="@6.3.2 +vaspsolpp",
+    )
+
     resource(
         name="vtsttools",
         url="https://theory.cm.utexas.edu/code/vtstcode-209.tgz",
         sha256="8f88265ab200ba61a3cbae119d05677e2744b5338fb9073ce6d901f38c17774b",
-        when="@6.5.1 +vtsttools"
+        when="@6.5.1,6.3.2 +vtsttools"
     )
 
     variant("openmp", default=False, when="@6:", description="Enable openmp build")
@@ -73,17 +81,28 @@ class Vasp(MakefilePackage, CudaPackage):
         description="Enable VASPsol implicit solvation model\n"
         "https://github.com/henniggroup/VASPsol",
     )
+    variant(
+        "vaspsolpp",
+        default=False,
+        when="@6.3.2",
+        description="Enable VASPsol++ implicit solvation model\n"
+        "https://github.com/VASPSol/VASPsol",
+    )
     variant("shmem", default=True, description="Enable use_shmem build flag")
     variant("hdf5", default=False, when="@6.2:", description="Enabled HDF5 support")
     variant(
         "vtsttools",
         default=False,
-        when="@6.5.1",
+        when="@6.3.2,6.5.1",
         description="Enable VASP TST Tools\n"
         "https://theory.cm.utexas.edu/vtsttools/index.html",
     )
 
     patch("vtsttools-6.5.1.patch", when="@6.5.1 +vtsttools")
+    patch("vtsttools-6.3.2.patch", when="@6.3.2 +vtsttools")
+    patch("vaspsol++-vasp_6.3.2.patch", when="@6.3.2 +vaspsolpp~vtsttools")
+    patch("vaspsol++-vtst-vasp_6.3.2.patch", when="@6.3.2 +vaspsolpp+vtsttools")
+    patch("vaspsol++-remove-intel.patch", when="@6.3.2 +vaspsolpp")
 
     depends_on("rsync", type="build")
     depends_on("blas")
@@ -286,13 +305,15 @@ class Vasp(MakefilePackage, CudaPackage):
                 cflags.extend(["-DGPUSHMEM=300", "-DHAVE_CUBLAS"])
                 filter_file(r"^CUDA_ROOT[ \t]*\?=.*$", spec["cuda"].prefix, make_include)
 
-        if spec.satisfies("+vaspsol"):
+        if spec.satisfies("+vaspsol") or spec.satisfies("+vaspsolpp"):
             cpp_options.append("-Dsol_compat")
             copy("VASPsol/src/solvation.F", "src/")
 
         if spec.satisfies("+vtsttools"):
             if spec.satisfies("@6.5.1"):
                 copy_tree("vtstcode-209/vtstcode6.5.1", "src")
+            elif spec.satisfies("@6.3.2"):
+                copy_tree("vtstcode-209/vtstcode6.3", "src")
 
         if spec.satisfies("+hdf5"):
             cpp_options.append("-DVASP_HDF5")

--- a/var/spack/repos/builtin/packages/vasp/vaspsol++-remove-intel.patch
+++ b/var/spack/repos/builtin/packages/vasp/vaspsol++-remove-intel.patch
@@ -1,0 +1,152 @@
+diff --git a/VASPsol/src/solvation.F b/VASPsol/src/solvation.F
+index 1fba277..ef8fb77 100644
+--- a/VASPsol/src/solvation.F
++++ b/VASPsol/src/solvation.F
+@@ -35,8 +35,6 @@
+ #define ifdsol !
+ #endif
+ 
+-#define ABORT      CALL TRACEBACKQQ; CALL M_exit(); CALL ABORT
+-
+ #define dsol_io ifdsol sol_io
+ 
+ 
+@@ -56,7 +54,6 @@ MODULE solvation_grid
+  USE poscar,  ONLY : type_info
+  USE lattice, ONLY : latt
+  USE mgrid,   ONLY : grid_3d
+- USE IFCORE
+ 
+  IMPLICIT NONE
+  
+@@ -1072,7 +1069,6 @@ MODULE solvation_lpcm
+  USE base
+  USE constant 
+  USE mpimy 
+- USE IFCORE
+  USE solvation_grid
+  
+  IMPLICIT NONE
+@@ -1516,7 +1512,6 @@ MODULE solvation_nlpcm
+  USE base
+  USE constant 
+  USE mpimy 
+- USE IFCORE
+  USE solvation_grid
+  
+  IMPLICIT NONE
+@@ -2355,7 +2350,7 @@ END SUBROUTINE SET_LPB
+  IF (LNLDIEL) THEN
+    ALLOCATE(x0(DIMREAL(GRIDC%MPLWV)))
+    x0 = PBETA*E_loc(:,4)
+-   CALL fzero_vec(F_floc, a, b, tol, f_loc, x0)
++   CALL fzero_vec(a, b, tol, f_loc, x0)
+  ELSE
+    f_loc = 1._q/(1._q - (alpha_pol+alpha0_rot)*invalpha_sic)
+  ENDIF
+@@ -2363,24 +2358,6 @@ END SUBROUTINE SET_LPB
+  DO I = 1,4
+    E_loc(:,I) = f_loc*E_loc(:,I)
+  END DO
+-
+- 
+-CONTAINS
+-
+-
+-ELEMENTAL REAL(q) FUNCTION F_floc(f_loc, x0)
+- REAL(q), INTENT(IN) :: f_loc, x0
+- REAL(q) :: x, g_rot
+- x = f_loc*x0
+- ! g_rot has relative fp error of 1e-8
+- IF (x < 2e-4_q) THEN
+-   g_rot = 1._q
+- ELSE
+-   g_rot = 3._q*(x-TANH(x))/(x**2*TANH(x))
+- ENDIF
+- F_floc = 1._q /(1._q - (g_rot*alpha0_rot + alpha_pol)*invalpha_sic) - f_loc  
+-END FUNCTION F_floc
+- 
+  
+ END SUBROUTINE SOLVE_E_LOC
+ 
+@@ -2390,20 +2367,13 @@ END SUBROUTINE SOLVE_E_LOC
+ !! Uses Brent's method - adapted from:
+ !!       https://people.math.sc.edu/Burkardt/f_src/brent/brent.f90
+ !!============================================================================
+-SUBROUTINE fzero_vec(f, a0, b0, tol, x, x0)
++SUBROUTINE fzero_vec(a0, b0, tol, x, x0)
+  
+  USE prec
+  
+  REAL(q), INTENT(IN)  :: a0, b0, tol, x0(:)
+  REAL(q), INTENT(OUT) :: x(:)
+  
+- INTERFACE
+-   ELEMENTAL REAL(q) FUNCTION f(x, x0)
+-   USE prec
+-      REAL(q), INTENT(IN) :: x, x0
+-   END FUNCTION f
+- END INTERFACE
+- 
+  REAL(q), ALLOCATABLE :: a(:), b(:), c(:), d(:), e(:), m(:), p(:), r(:), s1(:), s2(:), s3(:), fa(:), fb(:), fc(:)
+  REAL(q), ALLOCATABLE :: tol_abs(:)
+  
+@@ -2425,8 +2395,8 @@ SUBROUTINE fzero_vec(f, a0, b0, tol, x, x0)
+  
+  a  = a0
+  b  = b0
+- fa = f(a, x0)
+- fb = f(b, x0)
++ fa = calc_F(a, x0)
++ fb = calc_F(b, x0)
+  
+  !IF ( ANY( ((fa>0._q).AND.(fb>0._q)) .OR. ((fa<0._q).AND.(fb<0._q)) ) ) THEN
+  !  ABORT
+@@ -2509,12 +2479,28 @@ SUBROUTINE fzero_vec(f, a0, b0, tol, x, x0)
+    ! Next point
+    a = b; fa = fb
+    b = b + SIGN( MAX(ABS(d), tol_abs), m )
+-   fb = f(b, x0)
++   fb = calc_F(b, x0)
+    
+  ENDDO
+  
+  x = b
+  
++CONTAINS
++
++ FUNCTION calc_F(f_loc, x0) RESULT(F)
++   REAL(q), INTENT(IN) :: f_loc(:), x0(:)
++   REAL(q) :: F(SIZE(x0))
++   REAL(q) :: x(SIZE(x0)), g_rot(SIZE(x0))
++   x = f_loc*x0
++   ! g_rot has relative fp error of 1e-8
++   WHERE (x < 2e-4_q)
++      g_rot = 1._q
++   ELSEWHERE
++      g_rot = 3._q*(x-TANH(x))/(x**2*TANH(x))
++   ENDWHERE
++   F = 1._q /(1._q - (g_rot*alpha0_rot + alpha_pol)*invalpha_sic) - f_loc  
++ END FUNCTION calc_F
++ 
+ END SUBROUTINE fzero_vec
+ 
+ 
+@@ -3432,7 +3418,7 @@ END SUBROUTINE update_NELECT
+ !! check if Fermi level is converged for constant potential calculation
+ !!
+ !!====================================================================
+-PURE FUNCTION check_EFERMI(EFERMI)
++FUNCTION check_EFERMI(EFERMI)
+  
+  LOGICAL :: check_EFERMI
+  REAL(q), INTENT(IN) :: EFERMI
+@@ -3447,7 +3433,7 @@ END FUNCTION check_EFERMI
+ !! Constant potential calculation?
+ !!
+ !!====================================================================
+-PURE FUNCTION L_const_pot
++FUNCTION L_const_pot()
+  LOGICAL :: L_const_pot
+  L_const_pot = (EFERMI_ref < 0._q)
+ END FUNCTION L_const_pot

--- a/var/spack/repos/builtin/packages/vasp/vaspsol++-vasp_6.3.2.patch
+++ b/var/spack/repos/builtin/packages/vasp/vaspsol++-vasp_6.3.2.patch
@@ -1,0 +1,393 @@
+diff --git a/src/.objects b/src/.objects
+index eec4748..c70c8fa 100644
+--- a/src/.objects
++++ b/src/.objects
+@@ -108,6 +108,7 @@ SOURCE=\
+ 	Lebedev-Laikov.o \
+ 	stockholder.o \
+ 	dipol.o \
++	fileio.o \
+ 	solvation.o \
+ 	scpc.o \
+ 	pot.o \
+@@ -117,7 +118,6 @@ SOURCE=\
+ 	hamil_rot.o \
+ 	chain.o \
+ 	dyna.o \
+-	fileio.o \
+ 	vhdf5.o \
+ 	sphpro.o \
+ 	us.o \
+diff --git a/src/electron.F b/src/electron.F
+index b982151..7c83aa7 100644
+--- a/src/electron.F
++++ b/src/electron.F
+@@ -587,7 +587,7 @@
+ !=======================================================================
+       E%EBANDSTR=BANDSTRUCTURE_ENERGY(WDES, W)
+       TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS &
+-           +E%PAWAE+INFO%EALLAT+E%EXHF+ECORE()+Ediel_sol+E%ESCPC
++           +E%PAWAE+INFO%EALLAT+E%EXHF+ECORE()+Ecorr_sol+E%ESCPC
+ !-MM- Added to accomodate constrained moment calculations
+       IF (M_CONSTRAINED()) TOTEN=TOTEN+E_CONSTRAINT()
+       io_begin
+@@ -751,6 +751,10 @@
+       IF (LCORREL()) THEN
+          CALL SET_RHO_ONE_CENTRE(CRHODE,RHO_ONE_CENTRE)
+       ENDIF
++      
++! solvation - set SCF residual in vaspsol
++	  CALL SET_RMS_SCF(CHTOT,CHTOTL,MIX%LRESET)
++! solvation
+ 
+       IF (MIX%IMIX==4) THEN
+ !  broyden mixing ... :
+@@ -873,11 +877,11 @@
+     ! energy
+       IF (LCORREL()) THEN
+          WRITE(IO%IU6,7241) E%PSCENC,E%TEWEN,E%DENC,E%EXHF,E%XCENC,E%PAWPS,E%PAWAE, &
+-                         E%EENTROPY,E%EBANDSTR,INFO%EALLAT+ECORE(),Ediel_sol,TOTEN, &
++                         E%EENTROPY,E%EBANDSTR,INFO%EALLAT+ECORE(),Ecorr_sol,TOTEN, &
+                          TOTEN-E%EENTROPY,TOTEN-E%EENTROPY/(2+NORDER)   
+       ELSE
+          WRITE(IO%IU6,7240) E%PSCENC,E%TEWEN,E%DENC,E%EXHF,E%XCENC,E%PAWPS,E%PAWAE, &
+-                         E%EENTROPY,E%EBANDSTR,INFO%EALLAT,Ediel_sol,TOTEN, &
++                         E%EENTROPY,E%EBANDSTR,INFO%EALLAT,Ecorr_sol,TOTEN, &
+                          TOTEN-E%EENTROPY,TOTEN-E%EENTROPY/(2+NORDER)
+       ENDIF
+ 
+@@ -897,7 +901,7 @@
+      &        '  entropy T*S    EENTRO = ',F18.8/ &
+      &        '  eigenvalues    EBANDS = ',F18.8/ &
+      &        '  atomic energy  EATOM  = ',F18.8/ &
+-     &        '  Solvation  Ediel_sol  = ',F18.8/ &
++     &        '  Solvation  Ecorr_sol  = ',F18.8/ &
+      &        '  ---------------------------------------------------'/ &
+      &        '  free energy    TOTEN  = ',F18.8,' eV'// &
+      &        '  energy without entropy =',F18.8, &
+@@ -914,7 +918,7 @@
+      &        '  entropy T*S    EENTRO = ',F18.8/ &
+      &        '  eigenvalues    EBANDS = ',F18.8/ &
+      &        '  core contrib.  ECORE  = ',F18.8/ &
+-     &        '  Solvation  Ediel_sol  = ',F18.8/ &
++     &        '  Solvation  Ecorr_sol  = ',F18.8/ &
+      &        '  ---------------------------------------------------'/ &
+      &        '  free energy    TOTEN  = ',F18.8,' eV'// &
+      &        '  energy without entropy =',F18.8, &
+diff --git a/src/electron_OEP.F b/src/electron_OEP.F
+index b070964..6bb004d 100644
+--- a/src/electron_OEP.F
++++ b/src/electron_OEP.F
+@@ -591,7 +591,7 @@ SUBROUTINE ELMIN_OEP( &
+ ! TOTEN = total free energy of the system
+ !=======================================================================
+      E%EBANDSTR=BANDSTRUCTURE_ENERGY(WDES, WXI)
+-     TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ediel_sol
++     TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ecorr_sol
+      IF (M_CONSTRAINED()) TOTEN=TOTEN+E_CONSTRAINT()
+ 
+      DESUM(N)=TOTEN-TOTENL
+diff --git a/src/electron_all.F b/src/electron_all.F
+index ece2c3c..951003d 100644
+--- a/src/electron_all.F
++++ b/src/electron_all.F
+@@ -453,7 +453,7 @@
+ !---- calculate old band structure energy
+       E%EBANDSTR=BANDSTRUCTURE_ENERGY(WDES, W)
+ !---- old total energy
+-      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+E%EDOTP+Ediel_sol
++      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+E%EDOTP+Ecorr_sol
+ !---- for constrained moment calculations
+       IF (M_CONSTRAINED()) TOTEN=TOTEN+E_CONSTRAINT()
+       io_begin
+@@ -555,7 +555,7 @@
+       CALL PEAD_EDOTP(W,P,CQIJ,LATT_CUR,T_INFO,E2)
+ 
+       E2%EBANDSTR= BANDSTRUCTURE_ENERGY(WDES, W)
+-      TOTEN2=E2%EBANDSTR+E2%DENC+E2%XCENC+E2%TEWEN+E2%PSCENC+E2%EENTROPY+E2%PAWPS+E2%PAWAE+INFO%EALLAT+E2%EXHF+E2%EDOTP+Ediel_sol
++      TOTEN2=E2%EBANDSTR+E2%DENC+E2%XCENC+E2%TEWEN+E2%PSCENC+E2%EENTROPY+E2%PAWPS+E2%PAWAE+INFO%EALLAT+E2%EXHF+E2%EDOTP+Ecorr_sol
+ !---- in case of constrained moment calculations
+       IF (M_CONSTRAINED()) TOTEN2=TOTEN2+E_CONSTRAINT()
+       io_begin
+diff --git a/src/electron_lhf.F b/src/electron_lhf.F
+index 59c1f9f..072b83e 100644
+--- a/src/electron_lhf.F
++++ b/src/electron_lhf.F
+@@ -528,7 +528,7 @@ SUBROUTINE ELMIN_LHF( &
+      LHFCALC_FORCE=.FALSE.
+ 
+      E%EBANDSTR= BANDSTRUCTURE_ENERGY(WDES, W)
+-     TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ediel_sol
++     TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ecorr_sol
+ 
+      IF (M_CONSTRAINED()) TOTEN=TOTEN+E_CONSTRAINT()
+      io_begin
+diff --git a/src/elinear_response.F b/src/elinear_response.F
+index 3ed3064..ab27d16 100644
+--- a/src/elinear_response.F
++++ b/src/elinear_response.F
+@@ -448,7 +448,7 @@ electron: DO N=1,INFO%NELM
+        W1%CELTOT=   WXI%CELTOT
+ 
+        TOTENL=TOTEN
+-       TOTEN =E1%EBANDSTR+E1%DENC+E1%XCENC+E1%PAWPS+E1%PAWAE+E1%EENTROPY+Ediel_sol
++       TOTEN =E1%EBANDSTR+E1%DENC+E1%XCENC+E1%PAWPS+E1%PAWAE+E1%EENTROPY+Ecorr_sol
+        DE= (TOTEN-TOTENL)
+ 
+        IF (IO%IU0>=0) THEN
+diff --git a/src/force.F b/src/force.F
+index 1d3365e..1b72155 100644
+--- a/src/force.F
++++ b/src/force.F
+@@ -1341,6 +1341,9 @@ NOACC !$OMP END PARALLEL DO
+     INTEGER :: IRDMAA
+     LOGICAL,EXTERNAL :: USEFOCK_CONTRIBUTION
+     REAL(q) :: TOTEN
++! solvation
++    COMPLEX(q), ALLOCATABLE :: CHGWORK(:,:)
++! solvation
+ !tb beg
+     REAL(q),ALLOCATABLE,SAVE ::  RELVOL(:),RELCHG(:)
+     REAL(q),ALLOCATABLE,SAVE ::  Overlap(:,:),M2(:),HCD(:)
+@@ -1424,7 +1427,15 @@ NOACC !$OMP END PARALLEL DO
+ !     local contribution to force
+       CALL START_TIMING("G")
+ !$ACC UPDATE DEVICE(CHTOT) __IF_ASYNC__
+-      CALL FORLOC(GRIDC,P,T_INFO,LATT_CUR, CHTOT,EIFOR)
++! solvation
++! copy charge density to CHGWORK and add solvent charge density (bound+counterion)
++      ALLOCATE(CHGWORK(GRIDC%MPLWV,WDES%NCDIJ))
++      DO ISP=1,WDES%NCDIJ
++         CALL RC_ADD(CHTOT(1,ISP),1.0_q,CHTOT(1,ISP),0.0_q,CHGWORK(1,ISP),GRIDC)
++      ENDDO
++      CALL RC_ADD(CHGWORK(1,1),1.0_q,n_solv(1),1.0_q,CHGWORK(1,1),GRIDC)
++! solvation
++      CALL FORLOC(GRIDC,P,T_INFO,LATT_CUR, CHGWORK,EIFOR)
+       CALL STOP_TIMING("G",IO%IU6,'FORLOC')
+ 
+ 
+@@ -1491,7 +1502,7 @@ NOACC !$OMP END PARALLEL DO
+          CALL STRKIN(W,WDES, LATT_CUR%B,SIKEF)
+ ! local part
+          CALL STRELO(GRIDC,P,T_INFO,LATT_CUR, &
+-              CHTOT,CSTRF, INFO%NELECT, DSIF,EISIF,PSCSIF)
++              CHGWORK,CSTRF, INFO%NELECT, DSIF,EISIF,PSCSIF)
+ ! non-local part
+          IF (INFO%LREAL) THEN
+             CALL STRNLR(GRID,NONLR_S,P,LATT_CUR,W, &
+@@ -1677,10 +1688,6 @@ NOACC !$OMP END PARALLEL DO
+       CALL STOP_TIMING("G",IO%IU6,'OFIELD')
+ #endif
+ 
+-! solvation__
+-      TIFOR = TIFOR + EIFOR_SOL
+-! solvation__
+-
+ ! vdW force field correction
+       CALL VDW_CORRECTION_TO_FORCE(RELVOL)
+ 
+@@ -1833,9 +1840,6 @@ NOACC !$OMP END PARALLEL DO
+         DO J=1,T_INFO%NIONS
+         DO I=1,3
+           TEIFOR(I)=TEIFOR(I)+EIFOR (I,J)+PARFOR(I,J)+TAUFOR(I,J)
+-! solvation__
+-          TEIFOR(I)=TEIFOR(I)+EIFOR_SOL(I,J)
+-! solvation__
+           TEWIFO(I)=TEWIFO(I)+EWIFOR(I,J)
+           TFORNL(I)=TFORNL(I)+EINL (I,J)
+           THARFO(I)=THARFO(I)+HARFOR(I,J)
+@@ -2464,7 +2468,7 @@ NOACC !$OMP END PARALLEL DO
+                    NEDOS, 0, 0, DOS, DOSI, PAR, DOSPAR)
+ 
+               E%EBANDSTR=BANDSTRUCTURE_ENERGY(WDES, W)
+-              TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+EALLAT+E%EXHF+ECORE()+Ediel_sol
++              TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+EALLAT+E%EXHF+ECORE()+Ecorr_sol
+ 
+               IF (IO%IU6>=0) THEN
+                  NORDER=0 ; IF (KPOINTS%ISMEAR>=0) NORDER=KPOINTS%ISMEAR
+diff --git a/src/ilinear_response.F b/src/ilinear_response.F
+index 4f4aea3..55234c7 100644
+--- a/src/ilinear_response.F
++++ b/src/ilinear_response.F
+@@ -670,7 +670,7 @@ DOACC  CALL MRG_CELTOT(WDES,W1)
+        EFERMI1=(EFERMI1-EFERMI)*(1/POTIM)
+ 
+        TOTENL=TOTEN
+-       TOTEN =E1%EBANDSTR+E1%DENC+E1%XCENC+E1%PAWPS+E1%PAWAE+E1%EENTROPY+Ediel_sol
++       TOTEN =E1%EBANDSTR+E1%DENC+E1%XCENC+E1%PAWPS+E1%PAWAE+E1%EENTROPY+Ecorr_sol
+        DE= (TOTEN-TOTENL)
+        
+        IF (IO%IU0>=0) THEN
+diff --git a/src/linear_response.F b/src/linear_response.F
+index 1d9ec34..b65fbec 100644
+--- a/src/linear_response.F
++++ b/src/linear_response.F
+@@ -1225,7 +1225,7 @@ CONTAINS
+             LMDIM,CDIJ,CQIJ, RMS,DESUM,ICOUEV, SV, E%EXHF, IO%IU6,IO%IU0, .FALSE., .TRUE., .FALSE.)
+ 
+        E%EBANDSTR=BANDSTRUCTURE_ENERGY(WDES, W)
+-       TOTEN_=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ediel_sol
++       TOTEN_=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ecorr_sol
+ 
+        IF (IO%IU0>=0) THEN
+           WRITE(IO%IU0,1000) I, TOTEN_, TOTEN_-TOTEN, DESUM, ICOUEV, RMS
+diff --git a/src/main.F b/src/main.F
+index 3ab0f9b..e98adf2 100644
+--- a/src/main.F
++++ b/src/main.F
+@@ -908,7 +908,7 @@
+       CALL ELPH_READER(INCAR_F, ELPH_SETTINGS)
+       CALL ELPH_CHECK_INPUT_CONSISTENCY(INCAR_F, PHON_SETTINGS, ELPH_SETTINGS, POLAR_DATA)
+ ! solvation__
+-      CALL SOL_READER(T_INFO%NIONS,INFO%EDIFF,IO)
++      CALL SOL_READER(IO)
+ ! solvation__
+ ! bexternal__
+       CALL BEXT_READER(IO%IU0,IO%IU5)
+@@ -937,7 +937,7 @@
+ ! init all chains (INCAR reader)
+ !-----------------------------------------------------------------------
+       LCHAIN = IMAGES > 0 .AND. .NOT.AFQMC_SET % ACTIVE
+-      IF (LCHAIN) CALL chain_init( T_INFO, IO)
++      CALL chain_init( T_INFO, IO)
+ !-----------------------------------------------------------------------
+ !xml finish copying parameters from INCAR to xml file
+ ! no INCAR reading from here 
+@@ -3048,6 +3048,11 @@
+             ENDIF
+          ENDIF
+       ENDIF
++      
++! solvation__
++         CALL SOL_INIT(GRIDC, LATT_CUR, T_INFO, P, IO, INFO)
++! solvation__
++      
+ !***********************************************************************
+ !***********************************************************************
+ !
+@@ -4087,7 +4092,7 @@ ibrion: IF (DYN%IBRION==0) THEN
+ 
+            CALLMPI_C( sum_chain( EACC))
+ 
+-           IF ( LHYPER_NUDGE() ) EACC=1E10    ! energy not very accurate, use only force
++           IF ( LHYPER_NUDGE() .OR. L_const_pot() ) EACC=1E10    ! energy not very accurate, use only force
+ 
+            CALL IONCGR(IFLAG,T_INFO%NIONS,TOTEN,LATT_CUR%A,LATT_CUR%B,DYN%NFREE,DYN%POSION,DYN%POSIOC, &
+                 FACT,DYN%D2C,FACTSI,D2SIF,DYN%D2,DYN%D3,DISMAX,IO%IU6,IO%IU0, &
+@@ -4177,6 +4182,15 @@ io_end
+ 
+         ! use forces as stopping criterion if EDIFFG<0
+         IF (DYN%EDIFFG<0) INFO%LSTOP=LSTOP2
++        
++!-----------------------------------------------------------------------
++! update number of electrons for constant potential calculation
++!-----------------------------------------------------------------------
++        INFO%LSTOP = INFO%LSTOP .AND. check_EFERMI(EFERMI)
++        IF (.NOT. INFO%LSTOP) &
++           CALL update_NELECT(INFO%NELECT, EFERMI)
++!-----------------------------------------------------------------------
++        
+         io_begin
+         WRITE(TIU6,130)
+ 
+@@ -4639,7 +4653,7 @@ io_end
+      ! for the selfconsistent update set W_F%CELTOT and TOTEN now
+       IF (INFO%LONESW) W_F%CELTOT=W%CELTOT
+       E%EBANDSTR= BANDSTRUCTURE_ENERGY(WDES, W)
+-      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+Ediel_sol
++      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+Ecorr_sol
+ 
+       CALL STOP_TIMING("G",IO%IU6,'EDDIAG')
+ 
+@@ -4844,6 +4858,9 @@ io_end
+          io_end
+ ! comment out the following line to add  exchange correlation
+          IF (IO%LVHAR) CALL SET_LEXCH(-1)
++         ! solvation - write out ionic and bound charges in vaspsol
++         CALL SET_SOL_WRITE
++         ! solvation - 
+          CALL POTLOK(GRID,GRIDC,GRID_SOFT, WDES%COMM_INTER, WDES, &
+                   INFO,P,T_INFO,E,LATT_CUR, &
+                   CHTOT,CSTRF,CVTOT,DENCOR,SV, SOFT_TO_C,XCSIF)
+diff --git a/src/pot.F b/src/pot.F
+index 1d3b59d..ebfa7da 100644
+--- a/src/pot.F
++++ b/src/pot.F
+@@ -81,7 +81,7 @@
+       RGRID      DENCOR(GRIDC%RL%NP)
+       REAL(q)    XCSIF(3,3),TMPSIF(3,3)
+ ! work arrays (allocated after call to FEXCG)
+-      COMPLEX(q), ALLOCATABLE::  CWORK1(:),CWORK(:,:)
++      COMPLEX(q), ALLOCATABLE::  CWORK1(:),CWORK(:,:),CVHAR(:)
+       REAL(q) ELECTROSTATIC
+       LOGICAL, EXTERNAL :: L_NO_LSDA_GLOBAL
+ 
+@@ -97,7 +97,7 @@
+       PROFILING_START('potlok')
+ 
+       MWORK1=MAX(GRIDC%MPLWV,GRID_SOFT%MPLWV)
+-      ALLOCATE(CWORK1(MWORK1),CWORK(GRIDC%MPLWV,WDES%NCDIJ))
++      ALLOCATE(CWORK1(MWORK1),CWORK(GRIDC%MPLWV,WDES%NCDIJ),CVHAR(GRIDC%MPLWV))
+ !$ACC ENTER DATA COPYIN(CVTOT,CHTOT) CREATE(CWORK,CWORK1) __IF_ASYNC__
+ 
+ !-----------------------------------------------------------------------
+@@ -351,20 +351,14 @@
+ ! add the hartree potential and the double counting corrections
+ !-----------------------------------------------------------------------
+       CALL POTHAR(GRIDC, LATT_CUR, CHTOT, CWORK,E%DENC)
+-!$ACC PARALLEL LOOP PRESENT(CVTOT,CWORK) __IF_ASYNC__
++!$ACC PARALLEL LOOP PRESENT(CVHAR,CWORK) __IF_ASYNC__
+       DO I=1,GRIDC%RC%NP
+-         CVTOT(I,1)=CVTOT(I,1)+CWORK(I,1)
++         CVHAR(I) = CWORK(I,1)
+       ENDDO
+ !-----------------------------------------------------------------------
+ ! add external potential in reciprocal space
+ !-----------------------------------------------------------------------
+       CALL ADD_EXTERNAL_POTENTIAL(GRIDC, CVTOT)
+-! solvation__
+-!-----------------------------------------------------------------------
+-! add the dielectric corrections to CVTOT and the energy
+-!-----------------------------------------------------------------------
+-      CALL SOL_Vcorrection(INFO,T_INFO,LATT_CUR,P,WDES,GRIDC,CHTOT,CVTOT)
+-! solvation__
+ !-----------------------------------------------------------------------
+ !  add local pseudopotential potential
+ !-----------------------------------------------------------------------
+@@ -398,10 +392,21 @@
+       ! apply self consistent potential correction
+       CALL SCPC_APPLY(GRIDC, LATT_CUR, CHTOT, P, T_INFO, CSTRF, CVTOT, E%ESCPC)
+ 
+-!$ACC PARALLEL LOOP PRESENT(CVTOT,CWORK) __IF_ASYNC__
++!$ACC PARALLEL LOOP PRESENT(CVHAR,CWORK) __IF_ASYNC__
++      DO I=1,GRIDC%RC%NP
++         CVHAR(I) = CVHAR(I) + CWORK(I,1)
++      ENDDO
++      
++! solvation__
++!-----------------------------------------------------------------------
++! add the dielectric corrections to CVTOT and the energy
++!-----------------------------------------------------------------------
++      CALL SOL_Vcorrection(CHTOT, DENCOR, CVHAR)
+       DO I=1,GRIDC%RC%NP
+-         CVTOT(I,1)=CVTOT(I,1)+CWORK(I,1)
++         CVTOT(I,1)=CVTOT(I,1)+CVHAR(I)+V_corr(I)
+       ENDDO
++! solvation__
++      
+ ! bexternal__
+       IF (LBEXTERNAL()) CALL BEXT_ADDV(CVTOT,GRIDC,SIZE(CVTOT,2))
+ ! bexternal__
+diff --git a/src/subrot_scf.F b/src/subrot_scf.F
+index 3a6c7c0..f028bec 100644
+--- a/src/subrot_scf.F
++++ b/src/subrot_scf.F
+@@ -348,7 +348,7 @@ MODULE subrotscf
+ !=======================================================================
+       E%EBANDSTR=BANDSTRUCTURE_ENERGY(W%WDES, W)
+ 
+-      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ediel_sol
++      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ecorr_sol
+ 
+ !---- write total energy to OSZICAR file and stdout
+       DESUM(N)=TOTEN-TOTENL

--- a/var/spack/repos/builtin/packages/vasp/vaspsol++-vtst-vasp_6.3.2.patch
+++ b/var/spack/repos/builtin/packages/vasp/vaspsol++-vtst-vasp_6.3.2.patch
@@ -1,0 +1,463 @@
+diff --git a/src/.objects b/src/.objects
+index d07d0bb..82467a5 100644
+--- a/src/.objects
++++ b/src/.objects
+@@ -108,6 +108,7 @@ SOURCE=\
+ 	Lebedev-Laikov.o \
+ 	stockholder.o \
+ 	dipol.o \
++	fileio.o \
+ 	solvation.o \
+ 	scpc.o \
+ 	pot.o \
+@@ -121,7 +122,6 @@ SOURCE=\
+   opt.o \
+   chain.o \
+ 	dyna.o \
+-	fileio.o \
+ 	vhdf5.o \
+ 	sphpro.o \
+ 	us.o \
+diff --git a/vtstcode-209/vtstcode6.3/chain.F b/vtstcode-209/vtstcode6.3/chain.F
+index 85817fc..58ab05f 100644
+--- a/vtstcode-209/vtstcode6.3/chain.F
++++ b/vtstcode-209/vtstcode6.3/chain.F
+@@ -52,14 +52,14 @@
+     IMPLICIT NONE
+     SAVE
+     PRIVATE
+-    PUBLIC :: chain_force, chain_init, parallel_tempering
++    PUBLIC :: chain_force, chain_init, parallel_tempering, L_chain_opt_step
+     PUBLIC :: Sum_Chain, And_Chain, LHYPER_NUDGE, ML_chain_criteria
+     INTEGER mpmd_client_rank
+ #ifdef EAM
+     PRIVATE :: EAMForce
+ #endif
+     INTEGER :: ICHAIN, IOPT, ISIF_local
+-    LOGICAL :: optflag, fconverge, ftot_flag, LINTERACT, LMPMD
++    LOGICAL :: optflag, fconverge, ftot_flag, LINTERACT, LMPMD, L_opt_step
+     LOGICAL :: sconverge, cell_flag, twodim_flag
+     REAL(q) :: EDIFFG_local, ftot_val, jacobian, PSTRESS_local
+     REAL(q),ALLOCATABLE :: Free(:,:)
+@@ -479,6 +479,8 @@
+ 
+   147   CONTINUE
+ 
++        L_opt_step = .TRUE.
++        
+         IF (IOPT .NE. 0) THEN
+           hstress = stress
+           CALL sdotA(hstress,a)
+@@ -494,8 +496,10 @@
+           IF (.NOT. fconverge) THEN
+             ! our own optimizers (optflag: do or do not optimize)  
+             !CALL opt_step(optflag,posion,toten,force,hstress,a,b)
++            L_opt_step = optflag
+             CALL opt_step(optflag,posion,toten,force,hstress,a,b,&
+             ml_turnoff,Free,ml_chain_iter)
++            L_opt_step = L_opt_step .AND. .NOT. optflag
+             ! When ml_chain_iter=1, save force for the vasp stop criteria 
+             IF (ml_chain_iter == 1) THEN
+               ! For dimer/lanczos, force should be true-force
+@@ -517,8 +521,10 @@
+               sconverge = .TRUE.
+             ENDIF
+             IF (.NOT. sconverge) THEN
++              L_opt_step = optflag
+               CALL opt_step(optflag,posion,toten,force,hstress,a,b,&
+               ml_turnoff,Free,ml_chain_iter)
++              L_opt_step = L_opt_step .AND. .NOT. optflag
+               ! The returning force to main.F should be based on DFT
+               IF (ml_chain_iter == 1) THEN 
+                 ! For dimer/lanczos, force should be true-force
+@@ -553,6 +559,7 @@
+                   CALL dimer_fin(posion,a,b)
+                 END IF
+               ENDIF
++              L_opt_step = .TRUE.
+             ENDIF
+           ENDIF
+         ENDIF
+@@ -587,6 +594,17 @@
+     stress = stress_vasp
+ 
+     END SUBROUTINE chain_force
++    
++!**********************************************************************
++! Returns true if optimizer is active
++!**********************************************************************
++
++      FUNCTION L_chain_opt_step()
++      LOGICAL L_chain_opt_step
++      L_chain_opt_step = L_opt_step
++      END FUNCTION L_chain_opt_step
++
++!**********************************************************************
+ 
+ !**********************************************************************
+ !
+diff --git a/src/electron.F b/src/electron.F
+index b982151..7c83aa7 100644
+--- a/src/electron.F
++++ b/src/electron.F
+@@ -587,7 +587,7 @@
+ !=======================================================================
+       E%EBANDSTR=BANDSTRUCTURE_ENERGY(WDES, W)
+       TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS &
+-           +E%PAWAE+INFO%EALLAT+E%EXHF+ECORE()+Ediel_sol+E%ESCPC
++           +E%PAWAE+INFO%EALLAT+E%EXHF+ECORE()+Ecorr_sol+E%ESCPC
+ !-MM- Added to accomodate constrained moment calculations
+       IF (M_CONSTRAINED()) TOTEN=TOTEN+E_CONSTRAINT()
+       io_begin
+@@ -751,6 +751,10 @@
+       IF (LCORREL()) THEN
+          CALL SET_RHO_ONE_CENTRE(CRHODE,RHO_ONE_CENTRE)
+       ENDIF
++      
++! solvation - set SCF residual in vaspsol
++	  CALL SET_RMS_SCF(CHTOT,CHTOTL,MIX%LRESET)
++! solvation
+ 
+       IF (MIX%IMIX==4) THEN
+ !  broyden mixing ... :
+@@ -873,11 +877,11 @@
+     ! energy
+       IF (LCORREL()) THEN
+          WRITE(IO%IU6,7241) E%PSCENC,E%TEWEN,E%DENC,E%EXHF,E%XCENC,E%PAWPS,E%PAWAE, &
+-                         E%EENTROPY,E%EBANDSTR,INFO%EALLAT+ECORE(),Ediel_sol,TOTEN, &
++                         E%EENTROPY,E%EBANDSTR,INFO%EALLAT+ECORE(),Ecorr_sol,TOTEN, &
+                          TOTEN-E%EENTROPY,TOTEN-E%EENTROPY/(2+NORDER)   
+       ELSE
+          WRITE(IO%IU6,7240) E%PSCENC,E%TEWEN,E%DENC,E%EXHF,E%XCENC,E%PAWPS,E%PAWAE, &
+-                         E%EENTROPY,E%EBANDSTR,INFO%EALLAT,Ediel_sol,TOTEN, &
++                         E%EENTROPY,E%EBANDSTR,INFO%EALLAT,Ecorr_sol,TOTEN, &
+                          TOTEN-E%EENTROPY,TOTEN-E%EENTROPY/(2+NORDER)
+       ENDIF
+ 
+@@ -897,7 +901,7 @@
+      &        '  entropy T*S    EENTRO = ',F18.8/ &
+      &        '  eigenvalues    EBANDS = ',F18.8/ &
+      &        '  atomic energy  EATOM  = ',F18.8/ &
+-     &        '  Solvation  Ediel_sol  = ',F18.8/ &
++     &        '  Solvation  Ecorr_sol  = ',F18.8/ &
+      &        '  ---------------------------------------------------'/ &
+      &        '  free energy    TOTEN  = ',F18.8,' eV'// &
+      &        '  energy without entropy =',F18.8, &
+@@ -914,7 +918,7 @@
+      &        '  entropy T*S    EENTRO = ',F18.8/ &
+      &        '  eigenvalues    EBANDS = ',F18.8/ &
+      &        '  core contrib.  ECORE  = ',F18.8/ &
+-     &        '  Solvation  Ediel_sol  = ',F18.8/ &
++     &        '  Solvation  Ecorr_sol  = ',F18.8/ &
+      &        '  ---------------------------------------------------'/ &
+      &        '  free energy    TOTEN  = ',F18.8,' eV'// &
+      &        '  energy without entropy =',F18.8, &
+diff --git a/src/electron_OEP.F b/src/electron_OEP.F
+index b070964..6bb004d 100644
+--- a/src/electron_OEP.F
++++ b/src/electron_OEP.F
+@@ -591,7 +591,7 @@ SUBROUTINE ELMIN_OEP( &
+ ! TOTEN = total free energy of the system
+ !=======================================================================
+      E%EBANDSTR=BANDSTRUCTURE_ENERGY(WDES, WXI)
+-     TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ediel_sol
++     TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ecorr_sol
+      IF (M_CONSTRAINED()) TOTEN=TOTEN+E_CONSTRAINT()
+ 
+      DESUM(N)=TOTEN-TOTENL
+diff --git a/src/electron_all.F b/src/electron_all.F
+index ece2c3c..951003d 100644
+--- a/src/electron_all.F
++++ b/src/electron_all.F
+@@ -453,7 +453,7 @@
+ !---- calculate old band structure energy
+       E%EBANDSTR=BANDSTRUCTURE_ENERGY(WDES, W)
+ !---- old total energy
+-      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+E%EDOTP+Ediel_sol
++      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+E%EDOTP+Ecorr_sol
+ !---- for constrained moment calculations
+       IF (M_CONSTRAINED()) TOTEN=TOTEN+E_CONSTRAINT()
+       io_begin
+@@ -555,7 +555,7 @@
+       CALL PEAD_EDOTP(W,P,CQIJ,LATT_CUR,T_INFO,E2)
+ 
+       E2%EBANDSTR= BANDSTRUCTURE_ENERGY(WDES, W)
+-      TOTEN2=E2%EBANDSTR+E2%DENC+E2%XCENC+E2%TEWEN+E2%PSCENC+E2%EENTROPY+E2%PAWPS+E2%PAWAE+INFO%EALLAT+E2%EXHF+E2%EDOTP+Ediel_sol
++      TOTEN2=E2%EBANDSTR+E2%DENC+E2%XCENC+E2%TEWEN+E2%PSCENC+E2%EENTROPY+E2%PAWPS+E2%PAWAE+INFO%EALLAT+E2%EXHF+E2%EDOTP+Ecorr_sol
+ !---- in case of constrained moment calculations
+       IF (M_CONSTRAINED()) TOTEN2=TOTEN2+E_CONSTRAINT()
+       io_begin
+diff --git a/src/electron_lhf.F b/src/electron_lhf.F
+index 59c1f9f..072b83e 100644
+--- a/src/electron_lhf.F
++++ b/src/electron_lhf.F
+@@ -528,7 +528,7 @@ SUBROUTINE ELMIN_LHF( &
+      LHFCALC_FORCE=.FALSE.
+ 
+      E%EBANDSTR= BANDSTRUCTURE_ENERGY(WDES, W)
+-     TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ediel_sol
++     TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ecorr_sol
+ 
+      IF (M_CONSTRAINED()) TOTEN=TOTEN+E_CONSTRAINT()
+      io_begin
+diff --git a/src/elinear_response.F b/src/elinear_response.F
+index 3ed3064..ab27d16 100644
+--- a/src/elinear_response.F
++++ b/src/elinear_response.F
+@@ -448,7 +448,7 @@ electron: DO N=1,INFO%NELM
+        W1%CELTOT=   WXI%CELTOT
+ 
+        TOTENL=TOTEN
+-       TOTEN =E1%EBANDSTR+E1%DENC+E1%XCENC+E1%PAWPS+E1%PAWAE+E1%EENTROPY+Ediel_sol
++       TOTEN =E1%EBANDSTR+E1%DENC+E1%XCENC+E1%PAWPS+E1%PAWAE+E1%EENTROPY+Ecorr_sol
+        DE= (TOTEN-TOTENL)
+ 
+        IF (IO%IU0>=0) THEN
+diff --git a/src/force.F b/src/force.F
+index 1d3365e..1b72155 100644
+--- a/src/force.F
++++ b/src/force.F
+@@ -1341,6 +1341,9 @@ NOACC !$OMP END PARALLEL DO
+     INTEGER :: IRDMAA
+     LOGICAL,EXTERNAL :: USEFOCK_CONTRIBUTION
+     REAL(q) :: TOTEN
++! solvation
++    COMPLEX(q), ALLOCATABLE :: CHGWORK(:,:)
++! solvation
+ !tb beg
+     REAL(q),ALLOCATABLE,SAVE ::  RELVOL(:),RELCHG(:)
+     REAL(q),ALLOCATABLE,SAVE ::  Overlap(:,:),M2(:),HCD(:)
+@@ -1424,7 +1427,15 @@ NOACC !$OMP END PARALLEL DO
+ !     local contribution to force
+       CALL START_TIMING("G")
+ !$ACC UPDATE DEVICE(CHTOT) __IF_ASYNC__
+-      CALL FORLOC(GRIDC,P,T_INFO,LATT_CUR, CHTOT,EIFOR)
++! solvation
++! copy charge density to CHGWORK and add solvent charge density (bound+counterion)
++      ALLOCATE(CHGWORK(GRIDC%MPLWV,WDES%NCDIJ))
++      DO ISP=1,WDES%NCDIJ
++         CALL RC_ADD(CHTOT(1,ISP),1.0_q,CHTOT(1,ISP),0.0_q,CHGWORK(1,ISP),GRIDC)
++      ENDDO
++      CALL RC_ADD(CHGWORK(1,1),1.0_q,n_solv(1),1.0_q,CHGWORK(1,1),GRIDC)
++! solvation
++      CALL FORLOC(GRIDC,P,T_INFO,LATT_CUR, CHGWORK,EIFOR)
+       CALL STOP_TIMING("G",IO%IU6,'FORLOC')
+ 
+ 
+@@ -1491,7 +1502,7 @@ NOACC !$OMP END PARALLEL DO
+          CALL STRKIN(W,WDES, LATT_CUR%B,SIKEF)
+ ! local part
+          CALL STRELO(GRIDC,P,T_INFO,LATT_CUR, &
+-              CHTOT,CSTRF, INFO%NELECT, DSIF,EISIF,PSCSIF)
++              CHGWORK,CSTRF, INFO%NELECT, DSIF,EISIF,PSCSIF)
+ ! non-local part
+          IF (INFO%LREAL) THEN
+             CALL STRNLR(GRID,NONLR_S,P,LATT_CUR,W, &
+@@ -1677,10 +1688,6 @@ NOACC !$OMP END PARALLEL DO
+       CALL STOP_TIMING("G",IO%IU6,'OFIELD')
+ #endif
+ 
+-! solvation__
+-      TIFOR = TIFOR + EIFOR_SOL
+-! solvation__
+-
+ ! vdW force field correction
+       CALL VDW_CORRECTION_TO_FORCE(RELVOL)
+ 
+@@ -1833,9 +1840,6 @@ NOACC !$OMP END PARALLEL DO
+         DO J=1,T_INFO%NIONS
+         DO I=1,3
+           TEIFOR(I)=TEIFOR(I)+EIFOR (I,J)+PARFOR(I,J)+TAUFOR(I,J)
+-! solvation__
+-          TEIFOR(I)=TEIFOR(I)+EIFOR_SOL(I,J)
+-! solvation__
+           TEWIFO(I)=TEWIFO(I)+EWIFOR(I,J)
+           TFORNL(I)=TFORNL(I)+EINL (I,J)
+           THARFO(I)=THARFO(I)+HARFOR(I,J)
+@@ -2464,7 +2468,7 @@ NOACC !$OMP END PARALLEL DO
+                    NEDOS, 0, 0, DOS, DOSI, PAR, DOSPAR)
+ 
+               E%EBANDSTR=BANDSTRUCTURE_ENERGY(WDES, W)
+-              TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+EALLAT+E%EXHF+ECORE()+Ediel_sol
++              TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+EALLAT+E%EXHF+ECORE()+Ecorr_sol
+ 
+               IF (IO%IU6>=0) THEN
+                  NORDER=0 ; IF (KPOINTS%ISMEAR>=0) NORDER=KPOINTS%ISMEAR
+diff --git a/src/ilinear_response.F b/src/ilinear_response.F
+index 4f4aea3..55234c7 100644
+--- a/src/ilinear_response.F
++++ b/src/ilinear_response.F
+@@ -670,7 +670,7 @@ DOACC  CALL MRG_CELTOT(WDES,W1)
+        EFERMI1=(EFERMI1-EFERMI)*(1/POTIM)
+ 
+        TOTENL=TOTEN
+-       TOTEN =E1%EBANDSTR+E1%DENC+E1%XCENC+E1%PAWPS+E1%PAWAE+E1%EENTROPY+Ediel_sol
++       TOTEN =E1%EBANDSTR+E1%DENC+E1%XCENC+E1%PAWPS+E1%PAWAE+E1%EENTROPY+Ecorr_sol
+        DE= (TOTEN-TOTENL)
+        
+        IF (IO%IU0>=0) THEN
+diff --git a/src/linear_response.F b/src/linear_response.F
+index 1d9ec34..b65fbec 100644
+--- a/src/linear_response.F
++++ b/src/linear_response.F
+@@ -1225,7 +1225,7 @@ CONTAINS
+             LMDIM,CDIJ,CQIJ, RMS,DESUM,ICOUEV, SV, E%EXHF, IO%IU6,IO%IU0, .FALSE., .TRUE., .FALSE.)
+ 
+        E%EBANDSTR=BANDSTRUCTURE_ENERGY(WDES, W)
+-       TOTEN_=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ediel_sol
++       TOTEN_=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ecorr_sol
+ 
+        IF (IO%IU0>=0) THEN
+           WRITE(IO%IU0,1000) I, TOTEN_, TOTEN_-TOTEN, DESUM, ICOUEV, RMS
+diff --git a/src/main.F b/src/main.F
+index 1eaf5a9..9da475d 100644
+--- a/src/main.F
++++ b/src/main.F
+@@ -908,7 +908,7 @@
+       CALL ELPH_READER(INCAR_F, ELPH_SETTINGS)
+       CALL ELPH_CHECK_INPUT_CONSISTENCY(INCAR_F, PHON_SETTINGS, ELPH_SETTINGS, POLAR_DATA)
+ ! solvation__
+-      CALL SOL_READER(T_INFO%NIONS,INFO%EDIFF,IO)
++      CALL SOL_READER(IO)
+ ! solvation__
+ ! bexternal__
+       CALL BEXT_READER(IO%IU0,IO%IU5)
+@@ -3048,6 +3048,11 @@
+             ENDIF
+          ENDIF
+       ENDIF
++      
++! solvation__
++         CALL SOL_INIT(GRIDC, LATT_CUR, T_INFO, P, IO, INFO)
++! solvation__
++      
+ !***********************************************************************
+ !***********************************************************************
+ !
+@@ -4087,7 +4092,7 @@ ibrion: IF (DYN%IBRION==0) THEN
+ 
+            CALLMPI_C( sum_chain( EACC))
+ 
+-           IF ( LHYPER_NUDGE() ) EACC=1E10    ! energy not very accurate, use only force
++           IF ( LHYPER_NUDGE() .OR. L_const_pot() ) EACC=1E10    ! energy not very accurate, use only force
+ 
+            CALL IONCGR(IFLAG,T_INFO%NIONS,TOTEN,LATT_CUR%A,LATT_CUR%B,DYN%NFREE,DYN%POSION,DYN%POSIOC, &
+                 FACT,DYN%D2C,FACTSI,D2SIF,DYN%D2,DYN%D3,DISMAX,IO%IU6,IO%IU0, &
+@@ -4177,6 +4182,16 @@ io_end
+ 
+         ! use forces as stopping criterion if EDIFFG<0
+         IF (DYN%EDIFFG<0) INFO%LSTOP=LSTOP2
++        
++!-----------------------------------------------------------------------
++! update number of electrons for constant potential calculation
++!-----------------------------------------------------------------------
++        INFO%LSTOP = INFO%LSTOP .AND. check_EFERMI(EFERMI)
++        CALLMPI_C ( and_chain( INFO%LSTOP ))
++        IF (L_chain_opt_step() .AND. .NOT. INFO%LSTOP) &
++           CALL update_NELECT(INFO%NELECT, EFERMI)
++!-----------------------------------------------------------------------
++        
+         io_begin
+         WRITE(TIU6,130)
+ 
+@@ -4639,7 +4654,7 @@ io_end
+      ! for the selfconsistent update set W_F%CELTOT and TOTEN now
+       IF (INFO%LONESW) W_F%CELTOT=W%CELTOT
+       E%EBANDSTR= BANDSTRUCTURE_ENERGY(WDES, W)
+-      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+Ediel_sol
++      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+Ecorr_sol
+ 
+       CALL STOP_TIMING("G",IO%IU6,'EDDIAG')
+ 
+@@ -4844,6 +4859,9 @@ io_end
+          io_end
+ ! comment out the following line to add  exchange correlation
+          IF (IO%LVHAR) CALL SET_LEXCH(-1)
++         ! solvation - write out ionic and bound charges in vaspsol
++         CALL SET_SOL_WRITE
++         ! solvation - 
+          CALL POTLOK(GRID,GRIDC,GRID_SOFT, WDES%COMM_INTER, WDES, &
+                   INFO,P,T_INFO,E,LATT_CUR, &
+                   CHTOT,CSTRF,CVTOT,DENCOR,SV, SOFT_TO_C,XCSIF)
+diff --git a/src/pot.F b/src/pot.F
+index 1d3b59d..ebfa7da 100644
+--- a/src/pot.F
++++ b/src/pot.F
+@@ -81,7 +81,7 @@
+       RGRID      DENCOR(GRIDC%RL%NP)
+       REAL(q)    XCSIF(3,3),TMPSIF(3,3)
+ ! work arrays (allocated after call to FEXCG)
+-      COMPLEX(q), ALLOCATABLE::  CWORK1(:),CWORK(:,:)
++      COMPLEX(q), ALLOCATABLE::  CWORK1(:),CWORK(:,:),CVHAR(:)
+       REAL(q) ELECTROSTATIC
+       LOGICAL, EXTERNAL :: L_NO_LSDA_GLOBAL
+ 
+@@ -97,7 +97,7 @@
+       PROFILING_START('potlok')
+ 
+       MWORK1=MAX(GRIDC%MPLWV,GRID_SOFT%MPLWV)
+-      ALLOCATE(CWORK1(MWORK1),CWORK(GRIDC%MPLWV,WDES%NCDIJ))
++      ALLOCATE(CWORK1(MWORK1),CWORK(GRIDC%MPLWV,WDES%NCDIJ),CVHAR(GRIDC%MPLWV))
+ !$ACC ENTER DATA COPYIN(CVTOT,CHTOT) CREATE(CWORK,CWORK1) __IF_ASYNC__
+ 
+ !-----------------------------------------------------------------------
+@@ -351,20 +351,14 @@
+ ! add the hartree potential and the double counting corrections
+ !-----------------------------------------------------------------------
+       CALL POTHAR(GRIDC, LATT_CUR, CHTOT, CWORK,E%DENC)
+-!$ACC PARALLEL LOOP PRESENT(CVTOT,CWORK) __IF_ASYNC__
++!$ACC PARALLEL LOOP PRESENT(CVHAR,CWORK) __IF_ASYNC__
+       DO I=1,GRIDC%RC%NP
+-         CVTOT(I,1)=CVTOT(I,1)+CWORK(I,1)
++         CVHAR(I) = CWORK(I,1)
+       ENDDO
+ !-----------------------------------------------------------------------
+ ! add external potential in reciprocal space
+ !-----------------------------------------------------------------------
+       CALL ADD_EXTERNAL_POTENTIAL(GRIDC, CVTOT)
+-! solvation__
+-!-----------------------------------------------------------------------
+-! add the dielectric corrections to CVTOT and the energy
+-!-----------------------------------------------------------------------
+-      CALL SOL_Vcorrection(INFO,T_INFO,LATT_CUR,P,WDES,GRIDC,CHTOT,CVTOT)
+-! solvation__
+ !-----------------------------------------------------------------------
+ !  add local pseudopotential potential
+ !-----------------------------------------------------------------------
+@@ -398,10 +392,21 @@
+       ! apply self consistent potential correction
+       CALL SCPC_APPLY(GRIDC, LATT_CUR, CHTOT, P, T_INFO, CSTRF, CVTOT, E%ESCPC)
+ 
+-!$ACC PARALLEL LOOP PRESENT(CVTOT,CWORK) __IF_ASYNC__
++!$ACC PARALLEL LOOP PRESENT(CVHAR,CWORK) __IF_ASYNC__
++      DO I=1,GRIDC%RC%NP
++         CVHAR(I) = CVHAR(I) + CWORK(I,1)
++      ENDDO
++      
++! solvation__
++!-----------------------------------------------------------------------
++! add the dielectric corrections to CVTOT and the energy
++!-----------------------------------------------------------------------
++      CALL SOL_Vcorrection(CHTOT, DENCOR, CVHAR)
+       DO I=1,GRIDC%RC%NP
+-         CVTOT(I,1)=CVTOT(I,1)+CWORK(I,1)
++         CVTOT(I,1)=CVTOT(I,1)+CVHAR(I)+V_corr(I)
+       ENDDO
++! solvation__
++      
+ ! bexternal__
+       IF (LBEXTERNAL()) CALL BEXT_ADDV(CVTOT,GRIDC,SIZE(CVTOT,2))
+ ! bexternal__
+diff --git a/src/subrot_scf.F b/src/subrot_scf.F
+index 3a6c7c0..f028bec 100644
+--- a/src/subrot_scf.F
++++ b/src/subrot_scf.F
+@@ -348,7 +348,7 @@ MODULE subrotscf
+ !=======================================================================
+       E%EBANDSTR=BANDSTRUCTURE_ENERGY(W%WDES, W)
+ 
+-      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ediel_sol
++      TOTEN=E%EBANDSTR+E%DENC+E%XCENC+E%TEWEN+E%PSCENC+E%EENTROPY+E%PAWPS+E%PAWAE+INFO%EALLAT+E%EXHF+Ecorr_sol
+ 
+ !---- write total energy to OSZICAR file and stdout
+       DESUM(N)=TOTEN-TOTENL

--- a/var/spack/repos/builtin/packages/vasp/vtsttools-6.3.2.patch
+++ b/var/spack/repos/builtin/packages/vasp/vtsttools-6.3.2.patch
@@ -1,0 +1,61 @@
+diff --git a/src/.objects b/src/.objects
+index eec4748..d07d0bb 100644
+--- a/src/.objects
++++ b/src/.objects
+@@ -115,7 +115,11 @@ SOURCE=\
+ 	dos.o \
+ 	elf.o \
+ 	hamil_rot.o \
+-	chain.o \
++	bfgs.o dynmat.o instanton.o lbfgs.o sd.o cg.o dimer.o bbm.o \
++  fire.o lanczos.o neb.o qm.o \
++  pyamff_fortran/*.o ml_pyamff.o \
++  opt.o \
++  chain.o \
+ 	dyna.o \
+ 	fileio.o \
+ 	vhdf5.o \
+diff --git a/src/main.F b/src/main.F
+index 3ab0f9b..ceaf3bf 100644
+--- a/src/main.F
++++ b/src/main.F
+@@ -937,7 +937,7 @@
+ ! init all chains (INCAR reader)
+ !-----------------------------------------------------------------------
+       LCHAIN = IMAGES > 0 .AND. .NOT.AFQMC_SET % ACTIVE
+-      IF (LCHAIN) CALL chain_init( T_INFO, IO)
++      CALL chain_init( T_INFO, IO)
+ !-----------------------------------------------------------------------
+ !xml finish copying parameters from INCAR to xml file
+ ! no INCAR reading from here 
+@@ -3540,7 +3540,7 @@ io_end
+       ENDIF
+ 
+       CALL CHAIN_FORCE(T_INFO%NIONS,DYN%POSION,TOTEN,TIFOR, &
+-           LATT_CUR%A,LATT_CUR%B,IO%IU6)
++           TSIF,LATT_CUR%A,LATT_CUR%B,IO%IU6)
+ 
+       CALL PARALLEL_TEMPERING(NSTEP,T_INFO%NIONS,DYN%POSION,DYN%VEL,TOTEN,TIFOR,DYN%TEBEG,DYN%TEEND, &
+            LATT_CUR%A,LATT_CUR%B,IO%IU6)
+diff --git a/src/makefile b/src/makefile
+index 7fa1287..3c7c76b 100644
+--- a/src/makefile
++++ b/src/makefile
+@@ -14,7 +14,7 @@ OFLAG_4=
+ OFLAG=$(OFLAG_2)
+ OFLAG_IN=$(OFLAG)
+ 
+-LIB=lib parser
++LIB=lib parser pyamff_fortran
+ LLIB=-Llib -ldmy -Lparser -lparser
+ 
+ SRCDIR=../../src
+@@ -145,7 +145,7 @@ $(LIB):
+ 	$(MAKE) -C $@ -j1
+ #	$(MAKE) -C $@
+ 
+-dependencies: sources
++dependencies: sources libs
+ 	$(MAKE) depend
+ 
+ depend: $(F90SRC)


### PR DESCRIPTION
This PR adds support for using the VASPsol++ extension to VASP with version 6.3.2. Support is enabled for VASPsol++ both with and without VTSTtools. Patch files were supplied directly by Craig Plaisance, the author of VASPsol++. Slight modifications were made to the original patch files for compatibility with the Spack install process.
